### PR TITLE
Employee edits already created agreement objectives

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -17,7 +17,24 @@ class AgreementsController < ApplicationController
 
   def index
     @agreements = current_user.agreements.all
-    # @employees_reports = current_user.employees_reports
+    # @employees_agreements = current_user.employees_agreements
+  end
+
+  def edit
+    @agreement = Agreement.find(params[:id])
+    employee_only(@agreement) do
+      @agreement_form = AgreementFormFactory.new(@agreement).objectives
+    end
+  end
+
+  def update
+    @agreement_form = AgreementForm.new(objectives_params)
+    agreement = Agreement.find(params[:id])
+    employee_only(agreement) do
+      update_agreement(agreement, @agreement_form)
+
+      redirect_to action: :index
+    end
   end
 
 private
@@ -26,4 +43,7 @@ private
     params.require(:agreement_form).permit(*AgreementForm.allowed_params)
   end
 
+  def update_agreement(agreement, agreement_form)
+    agreement.update objective: agreement_form.objective_as_json
+  end
 end

--- a/app/models/agreement_form.rb
+++ b/app/models/agreement_form.rb
@@ -11,18 +11,18 @@ class AgreementForm
     end.flatten
   end
 
-  def self.allow_params_in_rows
+  def self.allowed_params_in_rows
     allowed_params.in_groups_of(5)
   end
 
-  AgreementForm.allow_params_in_rows.each do |row|
+  AgreementForm.allowed_params_in_rows.each do |row|
     row.each do |field|
       attr_accessor field
     end
   end
 
   def objective_as_json
-    AgreementForm.allow_params_in_rows.map do |row|
+    AgreementForm.allowed_params_in_rows.map do |row|
       row.each_with_object({}) do |field, hash|
         key = field[/(.+)_\d+/, 1].to_sym
         value = send(field)

--- a/app/models/agreement_form.rb
+++ b/app/models/agreement_form.rb
@@ -11,14 +11,18 @@ class AgreementForm
     end.flatten
   end
 
-  AgreementForm.allowed_params.in_groups_of(5).each do |row|
+  def self.allow_params_in_rows
+    allowed_params.in_groups_of(5)
+  end
+
+  AgreementForm.allow_params_in_rows.each do |row|
     row.each do |field|
       attr_accessor field
     end
   end
 
   def objective_as_json
-    AgreementForm.allowed_params.in_groups_of(5).map do |row|
+    AgreementForm.allow_params_in_rows.map do |row|
       row.each_with_object({}) do |field, hash|
         key = field[/(.+)_\d+/, 1].to_sym
         value = send(field)

--- a/app/models/agreement_form_factory.rb
+++ b/app/models/agreement_form_factory.rb
@@ -13,7 +13,7 @@ class AgreementFormFactory
 private
 
   def process_objective(form)
-    form_rows = AgreementForm.allow_params_in_rows
+    form_rows = AgreementForm.allowed_params_in_rows
 
     @agreement.objective.each_with_index do |objective, index|
       row = form_rows[index]

--- a/app/models/agreement_form_factory.rb
+++ b/app/models/agreement_form_factory.rb
@@ -1,0 +1,28 @@
+class AgreementFormFactory
+
+  def initialize(agreement)
+    @agreement = agreement
+  end
+
+  def objectives
+    AgreementForm.new.tap do |form|
+      process_objective(form)
+    end
+  end
+
+private
+
+  def process_objective(form)
+    form_rows = AgreementForm.allow_params_in_rows
+
+    @agreement.objective.each_with_index do |objective, index|
+      row = form_rows[index]
+      row.each do |field|
+        key = field.sub(/_\d+$/, '')
+        value = objective[key]
+        form.send("#{field}=", value)
+      end
+    end
+  end
+
+end

--- a/app/views/agreements/_form_fields.html.haml
+++ b/app/views/agreements/_form_fields.html.haml
@@ -22,7 +22,7 @@
         %span how is achievement of the objective being measured
 
   %tbody
-    - AgreementForm.allow_params_in_rows.each_with_index do |row, index|
+    - AgreementForm.allowed_params_in_rows.each_with_index do |row, index|
       - n = index + 1
       %tr{ class: "objective-row-#{n} #{(n)%2 == 0 ? 'even' : 'odd'}" }
         %td.number= n

--- a/app/views/agreements/_form_fields.html.haml
+++ b/app/views/agreements/_form_fields.html.haml
@@ -22,7 +22,7 @@
         %span how is achievement of the objective being measured
 
   %tbody
-    - AgreementForm.allowed_params.in_groups_of(5).each_with_index do |row, index|
+    - AgreementForm.allow_params_in_rows.each_with_index do |row, index|
       - n = index + 1
       %tr{ class: "objective-row-#{n} #{(n)%2 == 0 ? 'even' : 'odd'}" }
         %td.number= n

--- a/app/views/agreements/edit.html.haml
+++ b/app/views/agreements/edit.html.haml
@@ -1,0 +1,4 @@
+%h1 Edit Performance Agreement
+
+= form_for @agreement_form, url: agreement_path(@agreement), method: :put, html: {class: 'agreement-form'} do |form|
+  = render 'form_fields', f: form

--- a/app/views/agreements/index.html.haml
+++ b/app/views/agreements/index.html.haml
@@ -13,7 +13,7 @@
           %td= agreement.id
           %td
             - unless agreement.end_year_approved?
-              = #link_to('edit', edit_agreement_path(agreement))
+              = link_to('edit', edit_agreement_path(agreement))
 
             - if agreement.approved?
               - if agreement.mid_year_approved?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :reviews, only: [:edit, :update], constraints: { id: /mid_year|end_year/ }
   end
 
-  resources :agreements, only: [:new, :create, :index] do
+  resources :agreements, only: [:new, :create, :index, :edit, :update] do
   end
 
   resources :tokens, only: [:new, :create, :show]

--- a/features/employee_creates_and_changes_performance_agreement.feature
+++ b/features/employee_creates_and_changes_performance_agreement.feature
@@ -7,13 +7,14 @@ Feature:
     Given I am an employee
     And I log in
 
+  @javascript
   Scenario: Employee creates new set of agreement objectives when providing valid information
     Given I have no agreements created
     When I create new agreement with some objectives
     Then the agreement is saved
 
-  # @javascript
-  # Scenario: Employee edits already created objectives
-    # Given I have an existing report
-    # When I change the objectives on the report
-    # Then the changes are saved on the report
+  @javascript
+  Scenario: Employee edits already created objectives
+    Given I have an existing agreement
+    When I change the objectives on the agreement
+    Then the changes are saved on the agreement

--- a/features/employee_creates_and_changes_performance_agreement.feature
+++ b/features/employee_creates_and_changes_performance_agreement.feature
@@ -14,7 +14,7 @@ Feature:
     Then the agreement is saved
 
   @javascript
-  Scenario: Employee edits already created objectives
+  Scenario: Employee edits already created agreement objectives
     Given I have an existing agreement
     When I change the objectives on the agreement
     Then the changes are saved on the agreement

--- a/features/step_definitions/agreements_steps.rb
+++ b/features/step_definitions/agreements_steps.rb
@@ -22,14 +22,41 @@ Then(/^the agreement is saved$/) do
     { 'type' => '', 'what' => 'Learn english', 'how' => 'Read children books',
       'deliverable' => '', 'measurement' => '' },
     { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' },
-    { 'type' => '', 'what' => 'Bake pies', 'how' => '', 'deliverable' => '', 'measurement' => '' },
-    { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' },
-    { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' },
-    { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' },
-    { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' },
-    { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' },
-    { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' },
-    { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' }
-  ]
+    { 'type' => '', 'what' => 'Bake pies', 'how' => '', 'deliverable' => '', 'measurement' => '' }
+  ] + [{ 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' }] * 7
   expect(agreement.objective).to eql(expected)
+end
+
+Given(/^I have an existing agreement$/) do
+  @agreement = FactoryGirl.create(:filled_in_agreement, user: @user)
+end
+
+When(/^I change the objectives on the agreement$/) do
+  @page = UI::Pages::EditAgreement.new
+  @page.load(id: @agreement.id)
+
+  @page.form.what_field_1.set 'Learn spanish'
+  @page.form.how_field_1.set 'Read children books'
+
+  @page.form.add_objective.click
+  @page.form.add_objective.click
+  @page.form.what_field_3.set 'Bake pies'
+  @page.form.how_field_3.set 'Use the oven'
+
+  @page.form.save_button.click
+end
+
+Then(/^the changes are saved on the agreement$/) do
+  @agreement.reload
+
+  expected = [
+    { 'type' => '', 'what' => 'Learn spanish', 'how' => 'Read children books',
+      'deliverable' => '', 'measurement' => '' },
+    { 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' },
+    { 'type' => '', 'what' => 'Bake pies', 'how' => 'Use the oven',
+      'deliverable' => '', 'measurement' => '' }
+  ] + [{ 'type' => '', 'what' => '', 'how' => '', 'deliverable' => '', 'measurement' => '' }] * 7
+
+  expect(@agreement.objective).to eql(expected)
+
 end

--- a/features/support/ui/pages/edit_agreement.rb
+++ b/features/support/ui/pages/edit_agreement.rb
@@ -1,0 +1,11 @@
+require_relative '../sections/agreement_form'
+
+module UI
+  module Pages
+    class EditAgreement < SitePrism::Page
+      set_url '/agreements{/id}/edit'
+
+      section :form, UI::Sections::AgreementForm, 'form'
+    end
+  end
+end

--- a/features/support/ui/sections/agreement_form.rb
+++ b/features/support/ui/sections/agreement_form.rb
@@ -5,6 +5,7 @@ module UI
       element :how_field_1, '#agreement_form_how_1'
 
       element :what_field_3, '#agreement_form_what_3'
+      element :how_field_3, '#agreement_form_how_3'
 
       element :add_objective, '#add_objective'
 

--- a/spec/factories/agreements.rb
+++ b/spec/factories/agreements.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
   factory :agreement do
     factory :filled_in_agreement do
+      objective [
+        { type: '', what: 'Learn Ruby language', how: 'Join a weekly Ruby club', deliverable: '', measurement: '' }
+      ] + [{ type: '', what: '', how: '', deliverable: '', measurement: '' }] * 9
 
       factory :approved_agreement do
 


### PR DESCRIPTION
Implemented:
- Given I have an existing agreement
- When I change the objectives on the agreement
- Then the changes are saved on the agreement

Once again can be merged as user not yet taken to new index page after login.
