### PR TITLE
Prevent user creating more than one open report.

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -16,7 +16,7 @@ class AgreementsController < ApplicationController
   end
 
   def index
-    @agreements = current_user.agreements.all
+    @reports = current_user.agreements.all
     @employees_reports = current_user.employees_reports
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -3,7 +3,11 @@ class ReportsController < ApplicationController
   before_action :ensure_user
 
   def new
-    @report_form = ObjectivesForm.new
+    if current_user.report_open?
+      redirect_to action: :edit, id: current_user.open_report.id
+    else
+      @report_form = ObjectivesForm.new
+    end
   end
 
   def create

--- a/app/models/report_form_factory.rb
+++ b/app/models/report_form_factory.rb
@@ -5,6 +5,7 @@ class ReportFormFactory
 
   def objectives
     ObjectivesForm.new.tap do |form|
+      form.review_period = @report.review_period
       process_development(form, '')
       process_smart(form, '')
     end
@@ -14,6 +15,7 @@ class ReportFormFactory
     ReviewForm.new.tap do |form|
       column_set = "#{type}_review"
 
+      form.review_period = @report.review_period
       process_development(form, column_set)
       process_smart(form, column_set)
       process_comment(form, column_set)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,14 @@ class User < ActiveRecord::Base
 
   validates :email, presence: true, format: /\A.+@.+\z/, uniqueness: true
 
+  def report_open?
+    open_report.present?
+  end
+
+  def open_report
+    reports.detect { |r| !r.end_year_approved? }
+  end
+
   def email=(e)
     super normalize_email(e)
   end

--- a/app/views/reports/_your_reports.html.haml
+++ b/app/views/reports/_your_reports.html.haml
@@ -1,5 +1,4 @@
-- @agreements ||= @reports
-- unless @agreements.empty?
+- unless @reports.empty?
   %table.reports
     %thead
       %tr
@@ -9,7 +8,7 @@
         %th End year approval
         %th Action
     %tbody
-      - @agreements.each do |agreement|
+      - @reports.each do |agreement|
         %tr
           %td= agreement.updated_at.to_s(:long)
           %td

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -6,6 +6,7 @@
 %h2 Your performance reports
 = render 'your_reports'
 
-%p= link_to('Create new performance report', new_report_path)
+- if @reports.all? {|r| r.end_year_approved? }
+  %p= link_to('Create new performance report', new_report_path)
 
 = render 'employee_reports'

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -6,7 +6,7 @@
 %h2 Your performance reports
 = render 'your_reports'
 
-- if @reports.all? {|r| r.end_year_approved? }
+- unless current_user.report_open?
   %p= link_to('Create new performance report', new_report_path)
 
 = render 'employee_reports'

--- a/features/employee_creates_and_changes_objectives.feature
+++ b/features/employee_creates_and_changes_objectives.feature
@@ -18,3 +18,8 @@ Feature:
     Given I have an existing report
     When I change the objectives on the report
     Then the changes are saved on the report
+
+  Scenario: Employee with unclosed report tries to create new report
+    Given I have an existing report
+    When I view dashboard
+    Then I cannot create a new report

--- a/features/step_definitions/employee_creates_and_changes_objectives_steps.rb
+++ b/features/step_definitions/employee_creates_and_changes_objectives_steps.rb
@@ -1,4 +1,7 @@
 When(/^I create new report with some objectives$/) do
+  dashboard.load
+  expect(@dashboard.has_create_new_report?).to eq(true)
+
   @page = UI::Pages::NewReport.new
   @page.load
 
@@ -97,4 +100,12 @@ Then(/^the changes are saved on the report$/) do
     { 'what' => '', 'how' => '' }
   ]
   expect(@report.smart).to match_array(expected_smart)
+end
+
+When(/^I view dashboard$/) do
+  dashboard.load
+end
+
+Then(/^I cannot create a new report$/) do
+  expect(@dashboard.has_create_new_report?).to eq(false)
 end

--- a/features/step_definitions/employee_creates_and_changes_objectives_steps.rb
+++ b/features/step_definitions/employee_creates_and_changes_objectives_steps.rb
@@ -107,5 +107,5 @@ When(/^I view dashboard$/) do
 end
 
 Then(/^I cannot create a new report$/) do
-  expect(@dashboard.has_create_new_report?).to eq(false)
+  expect(@dashboard.has_no_create_new_report?).to eq(true)
 end

--- a/features/support/ui/pages/dashboard.rb
+++ b/features/support/ui/pages/dashboard.rb
@@ -13,6 +13,8 @@ module UI
       element :employee_initial_approval,  'table.employees-reports tbody tr:first td:nth-child(2)'
       element :employee_mid_year_approval, 'table.employees-reports tbody tr:first td:nth-child(3)'
       element :employee_end_year_approval, 'table.employees-reports tbody tr:first td:nth-child(4)'
+
+      element :create_new_report, 'a[href="/reports/new"]'
     end
   end
 end

--- a/spec/factories/management_reports.rb
+++ b/spec/factories/management_reports.rb
@@ -26,6 +26,10 @@ FactoryGirl.define do
                 { what: 'I can use Rails', how: 'I attended 6 times' }
               ] + [{ what: '', how: '' }] * 9
               end_year_review_comment 'It could not be a better year!'
+
+              factory :report_with_end_year_approved do
+                end_year_approved_at { 1.days.ago }
+              end
             end
           end
         end

--- a/spec/models/report_form_factory_spec.rb
+++ b/spec/models/report_form_factory_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe ReportFormFactory, type: :model do
       expect(subject.smart_what_1).to eql(management_report.smart[0]['what'])
       expect(subject.smart_how_1).to eql(management_report.smart[0]['how'])
     end
+
+    it 'assigns review_period' do
+      expect(subject.review_period).to eq(management_report.review_period)
+    end
   end
 
   describe '#review' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,4 +24,42 @@ RSpec.describe User, type: :model do
     expect(subject.email).to eql('user@example.com')
   end
 
+  context 'with only a end-year approved report' do
+    before do
+      subject.reports << FactoryGirl.build(:report_with_end_year_approved)
+    end
+
+    describe '.report_open?' do
+      it 'returns false' do
+        expect(subject.report_open?).to be_falsey
+      end
+    end
+
+    describe '.open_report' do
+      it 'returns nil' do
+        expect(subject.open_report).to be_nil
+      end
+    end
+  end
+
+  context 'with a report not end-year approved' do
+    let(:report) { FactoryGirl.build(:report_with_mid_year_approved) }
+
+    before do
+      subject.reports << report
+    end
+
+    describe '.report_open?' do
+      it 'returns true' do
+        expect(subject.report_open?).to be_truthy
+      end
+    end
+
+    describe '.open_report' do
+      it 'returns report' do
+        expect(subject.open_report).to eq(report)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
- Only show create new report link, when other reports are end-year approved.
- When user has open report, redirect new report url to edit report url.
